### PR TITLE
Add one-click domain migration utility

### DIFF
--- a/scripts/domain-menu/README.md
+++ b/scripts/domain-menu/README.md
@@ -1,1 +1,14 @@
 Domain Menu
+
+## One-Click Migrate
+
+`oneclick-migrate.sh` will:
+
+1. Ask for the domain name on the current server.
+2. Ask for the remote SSH username and server (IP or hostname).
+3. Archive `/var/www/<domain>` and dump `database_<domain>` with `mysqldump`.
+4. Transfer the archive to the destination server via `scp` and trigger `remote-restore.sh` over `ssh`.
+
+The destination server must allow SSH access for the provided user and have MySQL/MariaDB installed. The script copies `remote-restore.sh` automatically; it extracts the archive and imports the database into `database_<domain>`.
+
+The restore script uses `sudo` for privileged operations when the remote user is not root, so ensure the SSH user has passwordless sudo rights.

--- a/scripts/domain-menu/oneclick-migrate.sh
+++ b/scripts/domain-menu/oneclick-migrate.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# Script author: Muhamad Miguel Emmara
+# One click migrate domain and database to remote server
+
+set -e
+
+# Colours
+red=$'\e[1;31m'
+grn=$'\e[1;32m'
+yel=$'\e[1;33m'
+blu=$'\e[1;34m'
+mag=$'\e[1;35m'
+cyn=$'\e[1;36m'
+end=$'\e[0m'
+
+# Check if you are root
+if [ "$(whoami)" != 'root' ]; then
+     echo "You have no permission to run $0 as non-root user. Use sudo"
+     exit 1
+fi
+
+# Ensure required commands are available
+for cmd in mysqldump scp ssh mysql tar; do
+     if ! command -v "$cmd" >/dev/null 2>&1; then
+          echo "$cmd command not found. Please install it first."
+          exit 1
+     fi
+done
+
+# Variables
+domain=$1
+domain2=$2
+remote_user=$3
+remote_host=$4
+domainRegex="^[a-zA-Z0-9]"
+
+# Ask the user to add domain name and remote server info
+while true; do
+     clear
+     echo "########################### SERVER CONFIGURED BY MIGUEL EMMARA ###########################"
+     echo "                              ${grn}ONE CLICK MIGRATION${end}"
+     echo ""
+     echo "     __                                    "
+     echo "    / /   ___  ____ ___  ____  ____  __  __"
+     echo "   / /   / _ \\/ __ \`__ \\/ __ \\/_  / / / / /"
+     echo "  / /___/  __/ / / / / / /_/ / / /_/ /_/ /"
+     echo " /_____/\\___/_/ /_/ /_/ .___/ /___/\\__, /"
+     echo "                   /_/          /____/_/"
+     echo ""
+     echo "${grn}Press [CTRL + C] to cancel...${end}"
+     echo ""
+     echo "${blu}This option will migrate your domain and database to another server${end}"
+     echo "Here all the domain on you server"
+     echo ""
+     echo "_____________"
+     echo "${blu}"
+     ls -I default -I phpmyadmin -I filemanager -1 /etc/nginx/sites-enabled/
+     echo "${end}_____________"
+     echo ""
+     read -p ${grn}"Please provide domain${end}: " domain
+     read -p ${grn}"Please type your domain one more time${end}: " domain2
+     echo
+     [ "$domain" = "$domain2" ] && break
+     echo "Domain you provide does not match, please try again!"
+     read -p "${grn}Press [Enter] key to continue...${end}" readEnterKey
+done
+
+until [[ $domain =~ $domainRegex ]]; do
+     echo -n "Enter valid domain: "
+     read domain
+done
+
+# Remote info
+read -p ${grn}"Remote SSH username${end}: " remote_user
+read -p ${grn}"Remote server (IP or hostname)${end}: " remote_host
+
+# Check if domain is not there
+check_domain_exist() {
+     FILE=/etc/nginx/sites-available/$domain
+     file2=/var/www/$domain
+     if [ -f "$FILE" ] || [ -d "$file2" ]; then
+          clear
+     else
+          echo ""
+          echo "$domain does not exist, please try again"
+          exit
+     fi
+}
+
+# Archive domain and database
+create_archive() {
+     domainClear=${domain//./}
+     domainClear2=${domainClear//-/}
+     tmpdir=$(mktemp -d)
+     if ! mysql -e "SHOW DATABASES LIKE 'database_${domainClear2}'" | grep -q "database_${domainClear2}"; then
+          echo "Database database_${domainClear2} does not exist."
+          exit 1
+     fi
+     mysqldump database_$domainClear2 > "$tmpdir/db.sql"
+     cp -r /var/www/$domain "$tmpdir/"
+     tar -czf /tmp/${domainClear2}-migrate.tar.gz -C "$tmpdir" .
+     rm -rf "$tmpdir"
+}
+
+# Transfer archive and run remote restore
+transfer_remote() {
+     domainClear=${domain//./}
+     domainClear2=${domainClear//-/}
+     scp /tmp/${domainClear2}-migrate.tar.gz $remote_user@$remote_host:~/
+     scp /root/Lempzy/scripts/domain-menu/remote-restore.sh $remote_user@$remote_host:~/
+     ssh $remote_user@$remote_host "bash remote-restore.sh $domain ${domainClear2}-migrate.tar.gz"
+     rm -f /tmp/${domainClear2}-migrate.tar.gz
+}
+
+# Run
+check_domain_exist
+create_archive
+transfer_remote
+
+# Success Prompt
+clear
+echo "Script By"
+echo ""
+echo "     __                                    "
+echo "    / /   ___  ____ ___  ____  ____  __  __"
+echo "   / /   / _ \\/ __ \`__ \\/ __ \\/_  / / / / /"
+echo "  / /___/  __/ / / / / / /_/ / / /_/ /_/ /"
+echo " /_____/\\___/_/ /_/ /_/ .___/ /___/\\__, /"
+echo "                   /_/          /____/_/"
+echo ""
+echo "${blu}Migration to $remote_host completed for domain $domain${end}"
+
+echo ""

--- a/scripts/domain-menu/remote-restore.sh
+++ b/scripts/domain-menu/remote-restore.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Script author: Muhamad Miguel Emmara
+# Restore domain and database from migrated archive
+
+set -e
+
+# Colours
+red=$'\e[1;31m'
+grn=$'\e[1;32m'
+yel=$'\e[1;33m'
+blu=$'\e[1;34m'
+mag=$'\e[1;35m'
+cyn=$'\e[1;36m'
+end=$'\e[0m'
+
+# Use sudo when not running as root
+if [ "$(id -u)" -ne 0 ]; then
+     if ! command -v sudo >/dev/null 2>&1; then
+          echo "sudo command not found. Please install sudo or run as root."
+          exit 1
+     fi
+     SUDO="sudo"
+else
+     SUDO=""
+fi
+
+# Variables
+domain=$1
+archive=$2
+
+domainClear=${domain//./}
+domainClear2=${domainClear//-/}
+
+DB_CLIENT=$(command -v mysql || command -v mariadb)
+if [ -z "$DB_CLIENT" ]; then
+     echo "mysql or mariadb client not found. Please install a database client first."
+     exit 1
+fi
+
+if ! command -v tar >/dev/null 2>&1; then
+     echo "tar command not found. Please install tar first."
+     exit 1
+fi
+
+tmpdir=$(mktemp -d)
+tar -xzf "$archive" -C "$tmpdir"
+
+if [ -d "/var/www/$domain" ]; then
+     echo "/var/www/$domain already exists on destination. Aborting."
+     rm -rf "$tmpdir" "$archive"
+     exit 1
+fi
+
+$SUDO mv "$tmpdir/$domain" /var/www/
+$SUDO chown -R www-data:www-data /var/www/$domain
+
+$SUDO $DB_CLIENT <<MYSQL_SCRIPT
+CREATE DATABASE IF NOT EXISTS database_$domainClear2;
+MYSQL_SCRIPT
+
+$SUDO $DB_CLIENT database_$domainClear2 < "$tmpdir/db.sql"
+
+rm -rf "$tmpdir" "$archive"
+
+# Success Prompt
+echo "Script By"
+echo ""
+echo "     __                                    "
+echo "    / /   ___  ____ ___  ____  ____  __  __"
+echo "   / /   / _ \\/ __ \`__ \\/ __ \\/_  / / / / /"
+echo "  / /___/  __/ / / / / / /_/ / / /_/ /_/ /"
+echo " /_____/\\___/_/ /_/ /_/ .___/ /___/\\__, /"
+echo "                   /_/          /____/_/"
+echo ""
+echo "${blu}Restore completed for domain $domain${end}"
+
+echo ""

--- a/scripts/lempzy.sh
+++ b/scripts/lempzy.sh
@@ -211,11 +211,12 @@ sub_menu1() {
   echo "  2) ADD DOMAIN / SUB-DOMAIN + INSTALL WORDPRESS"
   echo "  3) SHOW CURRENT DOMAIN"
   echo "  4) BACKUP WEBSITE"
-  echo "  5) DELETE DOMAIN / SUB-DOMAIN"
-  echo "  6) BACK TO MAIN MENU <"
-  echo "  7) EXIT MENU${end}"
+  echo "  5) ONE-CLICK MIGRATE"
+  echo "  6) DELETE DOMAIN / SUB-DOMAIN"
+  echo "  7) BACK TO MAIN MENU <"
+  echo "  8) EXIT MENU${end}"
   echo ""
-  read -p "Choose your option [1-7]: " sub_menu_1
+  read -p "Choose your option [1-8]: " sub_menu_1
 
   while [ sub_menu_1 != '' ]; do
     if [[ $sub_menu_1 = "" ]]; then
@@ -280,6 +281,20 @@ sub_menu1() {
         ;;
 
       5)
+        # ONE-CLICK MIGRATE
+        ONECLICK_MIGRATE=/root/Lempzy/scripts/domain-menu/oneclick-migrate.sh
+
+        if test -f "$ONECLICK_MIGRATE"; then
+          source $ONECLICK_MIGRATE
+          cd && cd Lempzy
+        else
+          echo "${red}Cannot Migrate Domain${end}"
+        fi
+        read -p "${grn}Press [Enter] key to continue...${end}" readEnterKey
+        sub_menu1
+        ;;
+
+      6)
         # DELETE DOMAIN / SUB-DOMAIN
         DELETE_DOMAIN=/root/Lempzy/scripts/domain-menu/delete.sh
 
@@ -293,12 +308,12 @@ sub_menu1() {
         sub_menu1
         ;;
 
-      6)
+      7)
         clear
         main_menu
         ;;
 
-      7)
+      8)
         clear
         echo "Bye!"
         echo "You can open the Main Menu by typing ${grn}./lempzy.sh${end}"


### PR DESCRIPTION
## Summary
- add `oneclick-migrate.sh` to archive a domain and trigger remote restore, with dependency and database checks
- add `remote-restore.sh` for unpacking the archive and importing its database using sudo when required
- expose new ONE-CLICK MIGRATE option in domain menu
- document the migration workflow, sudo requirement, and SSH prerequisites

## Testing
- `bash -n scripts/domain-menu/oneclick-migrate.sh`
- `bash -n scripts/domain-menu/remote-restore.sh`
- `bash -n scripts/lempzy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c73f505ec48323a2d2e44f92903213