### PR TITLE
Improve OS detection and PHP repository handling

### DIFF
--- a/lempzy-setup.sh
+++ b/lempzy-setup.sh
@@ -35,24 +35,64 @@ mag=$'\e[1;35m'
 cyn=$'\e[1;36m'
 end=$'\e[0m'
 
-# Detect the operating system version.  In addition to the historical
-# releases that Lempzy supported (Debian 10/11 and Ubuntu 18.04/20.04/22.04/22.10),
-# we now support newer Debian (12 and 13) and Ubuntu (24.04) releases.
-OS_VERSION=$(lsb_release -rs)
+detect_os_metadata() {
+    if [[ -r /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        OS_ID=${ID,,}
+        OS_VERSION=${VERSION_ID}
+        OS_CODENAME=${VERSION_CODENAME:-}
+    fi
 
-# Reject unsupported versions early.  Note that we treat Debian releases as
-# integer strings (e.g. "12") and Ubuntu releases as dotted strings
-# (e.g. "24.04").  If your version isn't recognised here, the installer
-# will abort with a friendly message.  Update this list when adding
-# support for new distributions.
-if [[ "${OS_VERSION}" != "10" ]] && [[ "${OS_VERSION}" != "11" ]] && \
-   [[ "${OS_VERSION}" != "12" ]] && [[ "${OS_VERSION}" != "13" ]] && \
-   [[ "${OS_VERSION}" != "18.04" ]] && [[ "${OS_VERSION}" != "20.04" ]] && \
-   [[ "${OS_VERSION}" != "22.04" ]] && [[ "${OS_VERSION}" != "22.10" ]] && \
-   [[ "${OS_VERSION}" != "24.04" ]]; then
-     echo -e "${red}Sorry, this script is designed for DEBIAN (10, 11, 12, 13) and UBUNTU (18.04, 20.04, 22.04, 22.10, 24.04)${end}"
-     exit 1
+    if command -v lsb_release >/dev/null 2>&1; then
+        [[ -z ${OS_ID:-} ]] && OS_ID=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+        [[ -z ${OS_VERSION:-} ]] && OS_VERSION=$(lsb_release -rs)
+        [[ -z ${OS_CODENAME:-} ]] && OS_CODENAME=$(lsb_release -cs)
+    fi
+
+    if [[ -z ${OS_ID:-} ]] || [[ -z ${OS_VERSION:-} ]]; then
+        return 1
+    fi
+
+    export OS_ID OS_VERSION OS_CODENAME
+    return 0
+}
+
+if ! detect_os_metadata; then
+    echo -e "${red}Unable to detect the operating system. Lempzy currently supports Debian (10, 11, 12, 13) and Ubuntu (18.04, 20.04, 22.04, 22.10, 24.04).${end}"
+    exit 1
 fi
+
+is_supported_version() {
+    local version="$1"
+    shift
+    for supported in "$@"; do
+        if [[ "$supported" == "$version" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+case "$OS_ID" in
+    debian)
+        SUPPORTED_OS_VERSIONS=("10" "11" "12" "13")
+        ;;
+    ubuntu)
+        SUPPORTED_OS_VERSIONS=("18.04" "20.04" "22.04" "22.10" "24.04")
+        ;;
+    *)
+        echo -e "${red}Sorry, this script is designed for DEBIAN (10, 11, 12, 13) and UBUNTU (18.04, 20.04, 22.04, 22.10, 24.04).${end}"
+        exit 1
+        ;;
+esac
+
+if ! is_supported_version "$OS_VERSION" "${SUPPORTED_OS_VERSIONS[@]}"; then
+    echo -e "${red}Sorry, this script is designed for DEBIAN (10, 11, 12, 13) and UBUNTU (18.04, 20.04, 22.04, 22.10, 24.04).${end}"
+    exit 1
+fi
+
+SUPPORTED_PHP_VERSIONS=("7.2" "7.3" "7.4" "8.1" "8.2" "8.3" "8.4")
 
 # To ensure script run as root
 if [ "$EUID" -ne 0 ]; then
@@ -77,6 +117,11 @@ echo ""
 # Prompt for component versions and selections
 read -p "Enter desired PHP version (e.g. 8.2) [default: 8.2]: " PHP_VERSION
 PHP_VERSION=${PHP_VERSION:-8.2}
+PHP_VERSION=$(echo "$PHP_VERSION" | tr -d '[:space:]')
+if ! is_supported_version "$PHP_VERSION" "${SUPPORTED_PHP_VERSIONS[@]}"; then
+    echo -e "${red}Unsupported PHP version. Supported versions are: ${SUPPORTED_PHP_VERSIONS[*]}.${end}"
+    exit 1
+fi
 export PHP_VERSION
 
 read -p "Choose database engine (mariadb/mysql) [mariadb]: " DB_ENGINE

--- a/scripts/install/install_php.sh
+++ b/scripts/install/install_php.sh
@@ -13,16 +13,96 @@ end=$'\e[0m'
 
 PHP_VERSION=${PHP_VERSION:-8.2}
 
+SUPPORTED_PHP_VERSIONS=("7.2" "7.3" "7.4" "8.1" "8.2" "8.3" "8.4")
+
+is_supported_version() {
+     local version="$1"
+     shift
+     for supported in "$@"; do
+          if [[ "$supported" == "$version" ]]; then
+               return 0
+          fi
+     done
+     return 1
+}
+
+detect_os_metadata() {
+     if [[ -r /etc/os-release ]]; then
+          # shellcheck disable=SC1091
+          . /etc/os-release
+          OS_ID=${ID,,}
+          OS_CODENAME=${VERSION_CODENAME:-}
+     fi
+
+     if command -v lsb_release >/dev/null 2>&1; then
+          [[ -z ${OS_ID:-} ]] && OS_ID=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+          [[ -z ${OS_CODENAME:-} ]] && OS_CODENAME=$(lsb_release -cs)
+     fi
+
+     if [[ -z ${OS_ID:-} ]]; then
+          return 1
+     fi
+
+     export OS_ID OS_CODENAME
+     return 0
+}
+
+ensure_php_repository() {
+     detect_os_metadata || {
+          echo -e "${red}Unable to detect the operating system. Cannot configure PHP repository.${end}"
+          exit 1
+     }
+
+     if [[ "$OS_ID" == "debian" ]]; then
+          apt-get install -y ca-certificates apt-transport-https curl gnupg lsb-release
+          [[ -z ${OS_CODENAME:-} ]] && OS_CODENAME=$(lsb_release -cs)
+          if [[ -z ${OS_CODENAME:-} ]]; then
+               echo -e "${red}Unable to determine Debian codename for PHP repository.${end}"
+               exit 1
+          fi
+          local sury_list="/etc/apt/sources.list.d/sury-php.list"
+          if [[ ! -f "$sury_list" ]]; then
+               mkdir -p /usr/share/keyrings
+               curl -fsSL https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /usr/share/keyrings/sury-php.gpg
+               echo "deb [signed-by=/usr/share/keyrings/sury-php.gpg] https://packages.sury.org/php/ ${OS_CODENAME} main" > "$sury_list"
+          fi
+     elif [[ "$OS_ID" == "ubuntu" ]]; then
+          apt-get install -y software-properties-common ca-certificates curl
+          if ! grep -Rq "ondrej/php" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+               add-apt-repository -y ppa:ondrej/php
+          fi
+     else
+          echo -e "${red}Unsupported distribution: ${OS_ID}. Cannot configure PHP repository.${end}"
+          exit 1
+     fi
+}
+
+if ! is_supported_version "$PHP_VERSION" "${SUPPORTED_PHP_VERSIONS[@]}"; then
+     echo -e "${red}Unsupported PHP version. Supported versions are: ${SUPPORTED_PHP_VERSIONS[*]}.${end}"
+     exit 1
+fi
+
 install_php() {
      echo "${grn}Installing PHP ${PHP_VERSION} ...${end}"
      echo ""
      sleep 3
+     ensure_php_repository
      apt-get update
-     apt-get install -y php${PHP_VERSION}-fpm php${PHP_VERSION}-mysql
-     apt-get install -y php${PHP_VERSION} php${PHP_VERSION}-common php${PHP_VERSION}-zip php${PHP_VERSION}-curl \
-          php${PHP_VERSION}-xml php${PHP_VERSION}-xmlrpc php${PHP_VERSION}-mbstring php${PHP_VERSION}-gd \
-          php${PHP_VERSION}-imap php${PHP_VERSION}-cli php${PHP_VERSION}-bcmath php${PHP_VERSION}-intl \
-          php${PHP_VERSION}-opcache
+
+     local -a php_packages=("php${PHP_VERSION}-fpm" "php${PHP_VERSION}-mysql" "php${PHP_VERSION}")
+     local -a optional_modules=("common" "zip" "curl" "xml" "xmlrpc" "mbstring" "gd" "imap" "cli" "bcmath" "intl" "opcache")
+     local package
+
+     for module in "${optional_modules[@]}"; do
+          package="php${PHP_VERSION}-${module}"
+          if apt-cache show "$package" >/dev/null 2>&1; then
+               php_packages+=("$package")
+          else
+               echo "${yel}Package ${package} is not available in the configured repositories and will be skipped.${end}"
+          fi
+     done
+
+     apt-get install -y "${php_packages[@]}"
      echo ""
      sleep 1
 }

--- a/scripts/install/update_os.sh
+++ b/scripts/install/update_os.sh
@@ -11,8 +11,33 @@ mag=$'\e[1;35m'
 cyn=$'\e[1;36m'
 end=$'\e[0m'
 
-# Get OS Version
-OS_VERSION=$(lsb_release -rs)
+detect_os_metadata() {
+    if [[ -r /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        OS_ID=${ID,,}
+        OS_VERSION=${VERSION_ID}
+    fi
+
+    if command -v lsb_release >/dev/null 2>&1; then
+        [[ -z ${OS_ID:-} ]] && OS_ID=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+        [[ -z ${OS_VERSION:-} ]] && OS_VERSION=$(lsb_release -rs)
+    fi
+
+    if [[ -z ${OS_ID:-} ]] || [[ -z ${OS_VERSION:-} ]]; then
+        return 1
+    fi
+
+    export OS_ID OS_VERSION
+    return 0
+}
+
+if [[ -z ${OS_ID:-} ]] || [[ -z ${OS_VERSION:-} ]]; then
+    detect_os_metadata || {
+        echo -e "${red}Unable to determine the operating system. Aborting update.${end}"
+        exit 1
+    }
+fi
 
 # Update os
 update_os() {


### PR DESCRIPTION
## Summary
- add robust OS detection in the main setup script and validate supported Debian/Ubuntu releases and PHP versions
- configure appropriate PHP repositories for Debian (sury) and Ubuntu (ondrej) while skipping unavailable PHP modules at install time
- reuse OS detection in the update script to avoid failures on systems without lsb_release

## Testing
- bash -n lempzy-setup.sh
- bash -n scripts/install/install_php.sh
- bash -n scripts/install/update_os.sh

------
https://chatgpt.com/codex/tasks/task_e_68cfc095a0d4832386ae2827426cea4c